### PR TITLE
[I] keybinding,neotree

### DIFF
--- a/after/plugin/keymaps.lua
+++ b/after/plugin/keymaps.lua
@@ -10,7 +10,7 @@ keymap("n", "<C-Down>", ":resize +1<CR>", default_opts)
 
 -- Neotree
 keymap("n", "<C-o>", ":Neotree left reveal_force_cwd<cr>", default_opts) -- focus tree and reveal current file
-keymap("n", "<C-e>", ":Neotree toggle<cr>", default_opts) -- close tree 
+keymap("n", "<leader>e", ":Neotree toggle<cr>", default_opts) -- close tree 
 keymap("n", "<C-g>", ":Neotree toggle float git_status<cr>", default_opts) -- Show git status float
 
 -- ToggleTerm


### PR DESCRIPTION
Closed #1 : Changed neotree toggle keybinding from `CTRL+e` to `<leader>e`